### PR TITLE
Update Protobuf to a version that's built with Python 3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - libuuid
     - libxml2 2.9.*
     - krb5
-    - protobuf 3.0.*
+    - protobuf 3.3.*
   run:
     - boost 1.63.*
     - libgsasl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b68d112a3c234a50f646071b1de07e5e191018f6762492cd04d57390e1fd5a16
 
 build:
-  number: 4
+  number: 5
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
   skip: True  # [not linux]
 
@@ -31,7 +31,7 @@ requirements:
     - libuuid
     - libxml2 2.9.*
     - krb5
-    - protobuf 3.0.*
+    - protobuf 3.3.*
 
 test:
   commands:


### PR DESCRIPTION
Protobuf 3.0.* was never built for python 3.6, so packages that depend on libhdfs3 do not work on Python 3.6. This PR tries to update protobuf so other packages will also work.