### PR TITLE
meta.yaml: Allow builds for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+os: osx
+osx_image: xcode6.4
+
+env:
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "Om1coMUVszzqH9EZhjLc2YVdbqq6f5uYbwsqKqPykhYgy3z/2VXn25aXFdxjsqnl4dLaaTnQFeSduZJPRlHA5I2Ze3Z454JeHzoMCXkiyGEQZR7BUhVKG2ic0IX/J8LjH91NZza0z7RHUN24m+vq4RT6WHp/tWzqOsb4ElIjBQOowQw0UIoBLlJjzlMf7zai22eN+SU22oxMcnrcymuQIn55wPNsQ/bDsUdazljEy8x336OmxBE0VtuAj+QlyQ8MNwVOJwL7mmXlI6iDQWyS8M/Td/uyEh0x//Nca34fHzV6bE4pxKZAfy1f73fUrkd808A4RFCla51TbFmMrH9L2VMJ4Hm+TOkMPVkYG8ixedZC3hTTlz5IPkPVyh+MlrlI+LqEYifo0QKzMQRYXjb23fyzfHn8ZGaHLhzrFKdna5DloPdVxuZgIy87sTnffS0+eAdH7V7hITAL7vbDQo9lTjUNCU/ETkPHmfmH6zjDeX3o8sX7/Fk//r4IWR9iX/FK/2B8KeCubslmWfWoU0UBfNozzPurSVo2ctx+0b34lc/LVnJ5mTBSkMRMcUpVAcuGCnSCDyy5JZxzekabEnmgU69BnxFzJILWH41qFn/Msf1txVK2DYjqd3h1FO+HUOcJQkMdrJkVFu23qg3MC5n+gOBCPqzMik83chTmxhbo8qs="
+
+
+before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
+    # Remove homebrew.
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
+
+install:
+    # Install Miniconda.
+    - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
+      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      bash $MINICONDA_FILE -b
+
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
+      source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
+      conda config --add channels conda-forge
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
+
+script:
+  - conda build ./recipe
+
+  - upload_or_check_non_existence ./recipe conda-forge --channel=main

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/libhdfs3-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/libhdfs3-feedstock)
-OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/libhdfs3-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libhdfs3-feedstock)
 Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
 
 Current release info
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,13 +15,13 @@ source:
 build:
   number: 0
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
-  skip: True  # [not linux]
+  skip: True  # [win]
 
 requirements:
   build:
     - cmake
     - boost-cpp 1.64.*
-    - libgsasl 1.8.0 1
+    - libgsasl 1.8.*
     - libntlm
     - libuuid
     - libxml2 2.9.*
@@ -29,7 +29,7 @@ requirements:
     - protobuf 3.3.*
   run:
     - boost-cpp 1.64.*
-    - libgsasl 1.8.0 1
+    - libgsasl 1.8.*
     - libntlm
     - libuuid
     - libxml2 2.9.*
@@ -39,7 +39,8 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libhdfs3.so
+    - test -f $PREFIX/lib/libhdfs3.so  # [linux]
+    - test -f $PREFIX/lib/libhdfs3.dylib  # [osx]
 
 about:
   home: https://github.com/PivotalRD/libhdfs3


### PR DESCRIPTION
Aloow builds for osx.
For this, we relax the version requirement for libgsasl.
Also, change the test to test for existence for dylib files.

Required for https://github.com/conda-forge/hdfs3-feedstock/issues/10