### PR TITLE
Add dependency on openssl 1.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - CMakeLists.txt.diff
 
 build:
-  number: 1019
+  number: 1020
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
   skip: True  # [win]
 
@@ -31,6 +31,7 @@ requirements:
     - libuuid
     - libxml2
     - krb5
+    - openssl =1
   run:
     - boost-cpp
     - libgsasl 1.8.*
@@ -40,6 +41,7 @@ requirements:
     - libxml2
     - krb5
     - curl
+    - openssl =1
 
 test:
   commands:


### PR DESCRIPTION
libhdfs3 is now compatible with openssl 3.x
This commit is meant to publish an "openssl 1.x compatible" build on
conda-forge.

A later commit will bump the version of the dependency.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
